### PR TITLE
rabbitmq bitnamilegacy

### DIFF
--- a/deployments/docker/docker-compose.yaml
+++ b/deployments/docker/docker-compose.yaml
@@ -341,7 +341,7 @@ services:
       - mongo-db:/data
 
   rabbitmq:
-    image: "bitnami/rabbitmq:3.11"
+    image: "bitnamilegacy/rabbitmq:3.11"
     environment:
       RABBITMQ_DEFAULT_USER: "user"
       RABBITMQ_DEFAULT_PASS: "bitnami"


### PR DESCRIPTION
Reason for Change
The legacy image is required due to missing dependencies